### PR TITLE
13 frontend enhence usenavigatinguard

### DIFF
--- a/components/atoms/LoginButton.tsx
+++ b/components/atoms/LoginButton.tsx
@@ -3,7 +3,7 @@ import Icons from '../icons';
 
 export default function LoginButton() {
   return (
-    <Link href={`${process.env.NEXT_PUBLIC_BASE_URL}/auth/google`}>
+    <Link href='/moamoa/auth/google'>
       <a className='flex items-center justify-center gap-[0.6875rem] w-full max-w-[19.4375rem] h-16 border border-gray cursor-pointer rounded-[0.3125rem]'>
         <span className='block w-6 h-6'>
           <Icons.Google />

--- a/components/atoms/tests/LoginButton.test.tsx
+++ b/components/atoms/tests/LoginButton.test.tsx
@@ -12,8 +12,6 @@ describe('<LoginButton/>', () => {
 
     expect(loginButton).toBeInTheDocument();
     expect(loginButton).toHaveTextContent('골라라 구글 계정으로 로그인');
-    expect(loginButton.getAttribute('href')).toBe(
-      `${process.env.NEXT_PUBLIC_BASE_URL}/auth/google`
-    );
+    expect(loginButton.getAttribute('href')).toBe('/moamoa/auth/google');
   });
 });

--- a/hooks/useNavigationGuard.tsx
+++ b/hooks/useNavigationGuard.tsx
@@ -12,7 +12,13 @@ export default function useNavigationGuard() {
       AuthService.setAccessToken(data.accessToken);
       AuthService.refreshLogin(response.refetch);
     },
-    onError: (error) => {
+    onError: async (error: { status: number; message: string }) => {
+      const status = error.status;
+      if (status === 401) {
+        if (AuthService.accessToken) {
+          await AuthService.logout();
+        }
+      }
       router.replace('/login');
     }
   });

--- a/hooks/useNavigationGuard.tsx
+++ b/hooks/useNavigationGuard.tsx
@@ -7,8 +7,10 @@ export default function useNavigationGuard() {
   const response = useQuery(['auth'], AuthService.googleLogin, {
     retry: false,
     refetchOnWindowFocus: false,
+    enabled: !AuthService.accessToken,
     onSuccess: (data) => {
       AuthService.setAccessToken(data.accessToken);
+      AuthService.refreshLogin(response.refetch);
     },
     onError: (error) => {
       router.replace('/login');

--- a/next.config.js
+++ b/next.config.js
@@ -2,6 +2,14 @@
 const nextConfig = {
   reactStrictMode: true,
   swcMinify: true,
+  async rewrites() {
+    return [
+      {
+        source: '/moamoa/:path*',
+        destination: 'http://localhost:3000/:path*'
+      }
+    ];
+  },
   eslint: {
     dirs: ['./components', './pages', './__tests__']
   }

--- a/next.config.js
+++ b/next.config.js
@@ -6,7 +6,7 @@ const nextConfig = {
     return [
       {
         source: '/moamoa/:path*',
-        destination: 'http://localhost:3000/:path*'
+        destination: `${process.env.NEXT_PUBLIC_BASE_URL}/:path*`
       }
     ];
   },

--- a/pages/profile.tsx
+++ b/pages/profile.tsx
@@ -1,7 +1,23 @@
 import type { NextPage } from 'next';
 import Pages from '@/components/pages';
+import { dehydrate, QueryClient } from '@tanstack/react-query';
+import AuthService from '@/services/auth.service';
+import useNavigationGuard from '@/hooks/useNavigationGuard';
+
+export async function getStaticProps() {
+  const queryClient = new QueryClient();
+  await queryClient.prefetchQuery(['auth'], AuthService.googleLogin);
+
+  return {
+    props: {
+      dehydratedState: dehydrate(queryClient)
+    }
+  };
+}
 
 const Profile: NextPage = () => {
+  const response = useNavigationGuard();
+
   return <Pages.Profile />;
 };
 

--- a/services/auth.service.ts
+++ b/services/auth.service.ts
@@ -7,7 +7,6 @@ interface IAuthService {
 
 class AuthService implements IAuthService {
   private _accessToken: string | null = null;
-
   constructor() {
     // To do
   }
@@ -18,9 +17,7 @@ class AuthService implements IAuthService {
 
   async googleLogin(): Promise<IToken> {
     try {
-      const { data } = await axios.get<IToken>(
-        `${process.env.NEXT_PUBLIC_BASE_URL}/auth/auto-login`
-      );
+      const { data } = await axios.get<IToken>('/moamoa/auth/auto-login');
       return data;
     } catch (e: Error | AxiosError | unknown) {
       if (axios.isAxiosError(e)) {

--- a/services/auth.service.ts
+++ b/services/auth.service.ts
@@ -7,12 +7,21 @@ interface IAuthService {
 
 class AuthService implements IAuthService {
   private _accessToken: string | null = null;
+  private _updatedAtToken: number | null = null;
+  private timer: NodeJS.Timeout | undefined = undefined;
   constructor() {
     // To do
   }
 
   setAccessToken(value: string) {
     this._accessToken = value;
+    this._updatedAtToken = +new Date();
+  }
+
+  refreshLogin(callback: () => void) {
+    const DELAY_TIME = 1000 * 60 * 119;
+    clearTimeout(this.timer);
+    this.timer = setTimeout(callback, DELAY_TIME);
   }
 
   async googleLogin(): Promise<IToken> {

--- a/services/auth.service.ts
+++ b/services/auth.service.ts
@@ -24,15 +24,40 @@ class AuthService implements IAuthService {
     this.timer = setTimeout(callback, DELAY_TIME);
   }
 
+  async logout() {
+    try {
+      return await axios.get('/moamoa/auth/logout');
+    } catch (e) {
+      if (axios.isAxiosError(e)) {
+        throw {
+          status: e.response?.status,
+          message: e.message
+        };
+      }
+      throw {
+        status: 400,
+        message: 'Something went wrong'
+      };
+    }
+  }
+
   async googleLogin(): Promise<IToken> {
     try {
       const { data } = await axios.get<IToken>('/moamoa/auth/auto-login');
       return data;
     } catch (e: Error | AxiosError | unknown) {
       if (axios.isAxiosError(e)) {
-        throw new Error(e.message);
+        console.log('axious error');
+        console.log(e);
+        throw {
+          status: e.response?.status,
+          message: e.message
+        };
       }
-      throw new Error('Something went wrong');
+      throw {
+        status: 500,
+        message: 'Something went wrong'
+      };
     }
   }
 


### PR DESCRIPTION
# 업데이트 내용
### 로그인 연장 처리
- useNavigationGuard.tsx
```javascript
  const response = useQuery(['auth'], AuthService.googleLogin, {
    retry: false,
    refetchOnWindowFocus: false,
    enabled: !AuthService.accessToken, // accessToken이 없을 경우에만 해당 Hook을 실행합니다.
    onSuccess: (data) => {
      AuthService.setAccessToken(data.accessToken); 
      AuthService.refreshLogin(response.refetch); // 1시간 59분 뒤에 refreshLogin을 실행합니다.
    },
    onError: (error) => {
      router.replace('/login');
    }
  });
```

- Auth.service.ts
```javascript
 refreshLogin(callback: () => void) {
    // 콜백을 파라미터로 받아서 1시간 59분 뒤에 실행
    const DELAY_TIME = 1000 * 60 * 119;
    clearTimeout(this.timer);
    this.timer = setTimeout(callback, DELAY_TIME);
  }
```


### Proxy 처리
- next.config.js
```javascript
const nextConfig = {
  reactStrictMode: true,
  swcMinify: true,
  async rewrites() {
    // '/moamoa'로 시작하는 url을 환경변수 url로 우회시킨다.
    // 이 설정을 하지 않으면 cors block 에러가 나네요.
    return [
      {
        source: '/moamoa/:path*',
        destination: `${process.env.NEXT_PUBLIC_BASE_URL}/:path*`
      }
    ];
  },
  eslint: {
    dirs: ['./components', './pages', './__tests__']
  }
};
```